### PR TITLE
Fix broken image source for Build Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="docs/epsilon.svg?sanitize=true" alt="NumWorks Epsilon logo" height="70" >
 
-[![Build Status](https://github.com/numworks/epsilon/workflows/Continuous%20integration/badge.svg)](https://github.com/numworks/epsilon/actions?workflow=Continuous+integration)
+[![Build Status](https://github.com/numworks/epsilon/actions/workflows/ci.yml/badge.svg)](https://github.com/numworks/epsilon/actions/workflows/ci.yml)
 
 Epsilon is a high-performance graphing calculator operating system. It includes eight apps that cover the high school mathematics curriculum.
 


### PR DESCRIPTION
The CI build status badge was a broken image. This fixes the URLs.